### PR TITLE
Fix 33: Array to string conversion when putting a Rating Block

### DIFF
--- a/src/Page/PageList.php
+++ b/src/Page/PageList.php
@@ -18,6 +18,8 @@ class PageList extends \Concrete\Core\Page\PageList
         $this->query->addSelect('SUM(r.ratedValue) AS ratings');
         $this->query->addSelect('r.bID');
         $this->query->addGroupBy('p.cID');
+        $this->query->addGroupBy('r.bID');
+        $this->query->addGroupBy('p.cDisplayOrder');
     }
 
     public function filterByUserRated(int $uID): void

--- a/src/Traits/RatingTrait.php
+++ b/src/Traits/RatingTrait.php
@@ -60,8 +60,10 @@ trait RatingTrait
             $time = time();
         }
         $config = $app->make('config/database');
-
-        return $time . ':' . md5($time . ':' . $uID . ':' . $action . ':' . $config->get('concrete.security.token.validation'));
+        $actionArray = array_map('strval', $action); //makes sure that $action is a string
+        $actionString = implode(':', $actionArray); //properly dealing with the array to string
+        $actionString = str_replace(' ', '_', $actionString); //treating all spaces in the string
+        return $time . ':' . md5($time . ':' . $uID . ':' . $actionString . ':' . $config->get('concrete.security.token.validation'));
     }
 
     public function validate($action = '', $token = null, $uID = 0): bool


### PR DESCRIPTION
This is a proposed fix for the bug [#33](https://github.com/concrete5cojp/c5j_ratings/issues/33). 2 files are modified:
`src/Traits/RatingTrait.php` - Fixed the `$action` variable, making sure it contains a string and not an array, treating correctly the data it contains.
`src/Page/PageList.php` - Added 2 lines in the SQL query to `GROUP BY` correctly with `r.bID` and `p.cDisplayOrder`.