### PR TITLE
Fix 35: Rating counts of rating blocks are now being stored in database

### DIFF
--- a/src/Page/PageList.php
+++ b/src/Page/PageList.php
@@ -18,6 +18,8 @@ class PageList extends \Concrete\Core\Page\PageList
         $this->query->addSelect('SUM(r.ratedValue) AS ratings');
         $this->query->addSelect('r.bID');
         $this->query->addGroupBy('p.cID');
+        $this->query->addGroupBy('r.bID');
+        $this->query->addGroupBy('p.cDisplayOrder');
     }
 
     public function filterByUserRated(int $uID): void

--- a/src/Traits/RatingTrait.php
+++ b/src/Traits/RatingTrait.php
@@ -60,10 +60,7 @@ trait RatingTrait
             $time = time();
         }
         $config = $app->make('config/database');
-        $actionArray = array_map('strval', $action); //makes sure that $action is a string
-        $actionString = implode(':', $actionArray); //properly dealing with the array to string
-        $actionString = str_replace(' ', '_', $actionString); //treating all spaces in the string
-        return $time . ':' . md5($time . ':' . $uID . ':' . $actionString . ':' . $config->get('concrete.security.token.validation'));
+        return $time . ':' . md5($time . ':' . $uID . ':' . $action . ':' . $config->get('concrete.security.token.validation'));
     }
 
     public function validate($action = '', $token = null, $uID = 0): bool

--- a/src/Traits/RatingTrait.php
+++ b/src/Traits/RatingTrait.php
@@ -60,8 +60,10 @@ trait RatingTrait
             $time = time();
         }
         $config = $app->make('config/database');
-
-        return $time . ':' . md5($time . ':' . $uID . ':' . $action . ':' . $config->get('concrete.security.token.validation'));
+        $actionArray = array_map('strval', $action); //makes sure that $action is a string
+        $actionString = implode(':', $actionArray); //properly dealing with the array to string
+        $actionString = str_replace(' ', '_', $actionString); //treating all spaces in the string
+        return $time . ':' . md5($time . ':' . $uID . ':' . $actionString . ':' . $config->get('concrete.security.token.validation'));
     }
 
     public function validate($action = '', $token = null, $uID = 0): bool


### PR DESCRIPTION
This is a proposed fix for the bug [#35](https://github.com/concrete5cojp/c5j_ratings/issues/35). 1 file is modified:
`src/Traits/RatingTrait.php` - Fixed the error when you clicked on a rating block interaction, like the heart or clap icon, it wouldn't update the count of interactions on the website or in the database. The treatment from the `$action` variable in the previous pull request was taken away, leaving the variable as an array.
The `PageList.php` file from the previous pull request is the same, enabling the update in the database and showing the interaction on the website correctly.